### PR TITLE
Don't link in compile commands

### DIFF
--- a/src/main/java/edu/wpi/first/vscode/tooling/models/CompileCommandImpl.java
+++ b/src/main/java/edu/wpi/first/vscode/tooling/models/CompileCommandImpl.java
@@ -76,6 +76,7 @@ public class CompileCommandImpl implements CompileCommand {
       cmd.append(' ');
     }
 
+    cmd.append("-c "); // Don't link.
     cmd.append('"');
     cmd.append(file.getAbsolutePath());
     cmd.append('"');


### PR DESCRIPTION
I hope this fixes some issues with compile commands, I was able to sort-of test this on macOS using
```python
from os import chdir, system
from json import loads

commands = loads(open("compile_commands.json", "r").read())

for command in commands:
    chdir(command["directory"])
    system(command["command"])# + " -c")
``` 

I think linking is not possible per each source file, as you'd have to compile the entire project for that.

EDIT: this seems to work with clangd and clion on macOS.